### PR TITLE
remove homepage configuration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "nuevofoundation-web",
-  "homepage": ".",
   "version": "0.1.0",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Previously build files weren't hosted in the server root path so this config option was used - removing it since now the build files are hosted in server root path. 

More info on this change here 
https://create-react-app.dev/docs/deployment/#building-for-relative-paths