### PR TITLE
Add Bold Journey feature link for Ximena Cortez on home page (#318)

### DIFF
--- a/src/components/static/pages/Home.tsx
+++ b/src/components/static/pages/Home.tsx
@@ -453,7 +453,11 @@ export class Home extends React.Component<{}, StatProps> {
             </LogoSectionImageContent>
 
             <LogoSectionImageContent>
-              <div className="apply-logo-css-filter"><a href="https://boldjourney.com/meet-beatris-mendez-gandica/" target="_blank" rel="noreferrer"><img src={BoldJourneyLogoImage} alt="Bold Journey Logo" /></a></div>
+              <div className="apply-logo-css-filter"><a href="https://boldjourney.com/meet-beatris-mendez-gandica/" target="_blank" rel="noreferrer"><img src={BoldJourneyLogoImage} alt="Bold Journey Logo - Beatris Mendez Gandica" /></a></div>
+            </LogoSectionImageContent>
+
+            <LogoSectionImageContent>
+              <div className="apply-logo-css-filter"><a href="https://boldjourney.com/meet-ximena-cortez/" target="_blank" rel="noreferrer"><img src={BoldJourneyLogoImage} alt="Bold Journey Logo - Ximena Cortez" /></a></div>
             </LogoSectionImageContent>
 
           </LogoSection>


### PR DESCRIPTION
## Summary
Implements issue #318 — adds a second **Bold Journey** publication logo to the home page "featured in" logo section, linking to [Ximena Cortez's feature](https://boldjourney.com/meet-ximena-cortez/), alongside the existing Beatris Mendez Gandica feature.

## Changes
- Added a new Bold Journey logo entry linking to https://boldjourney.com/meet-ximena-cortez/ (reuses the existing Bold Journey logo asset — same publication).
- Made both Bold Journey logo `alt` texts specific to each honoree (Beatris / Ximena) for accessibility, since two identical logos would otherwise share ambiguous alt text.

## Verification
- `tsc --noEmit` clean
- Local dev-server render check (Playwright): home page renders with **2** Bold Journey anchors (Beatris + Ximena), **zero** console errors.
- Ximena's Bold Journey URL returns HTTP 200.

Fixes #318